### PR TITLE
Replace const with var to make bundle output friendlier to old IE.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ module.exports = function (content) {
 
   this.emitFile(url, content);
 
-  const cdn = "const url = " + JSON.stringify(url) + ";\n" + 
-    "const cdnUrl = typeof _wml !== \"undefined\" && _wml.cdn && _wml.cdn.map(url);\n";
+  const cdn = "var url = " + JSON.stringify(url) + ";\n" + 
+    "var cdnUrl = typeof _wml !== \"undefined\" && _wml.cdn && _wml.cdn.map(url);\n";
 
   return cdn + "module.exports = cdnUrl || __webpack_public_path__ + url;";
 };


### PR DESCRIPTION
Our Electrode-generated production bundle isn't compatible with IE < 11, simply because the electrode-cdn-file-loader is outputting code that uses `const`, which doesn't get transformed by Babel. Replacing `const` with `var` is a simple fix that allows us to serve code that works cross-browser.